### PR TITLE
Add automatic EF Core migrations on startup

### DIFF
--- a/SkillLearning.Api/Program.cs
+++ b/SkillLearning.Api/Program.cs
@@ -3,10 +3,12 @@ using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using Amazon.XRay.Recorder.Handlers.AwsSdk.Internal;
 using AspNetCore.Swagger.Themes;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using SkillLearning.Api.Extensions;
 using SkillLearning.Api.Middlewares;
+using SkillLearning.Infrastructure.Persistence;
 using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -45,6 +47,23 @@ builder.Services.AddCustomServices(builder.Configuration);
 
 // App
 var app = builder.Build();
+
+// Auto Migrations
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    try
+    {
+        var context = services.GetRequiredService<ApplicationDbContext>();
+        await context.Database.MigrateAsync();
+    }
+    catch (Exception ex)
+    {
+        var logger = services.GetRequiredService<ILogger<Program>>();
+        logger.LogError(ex, "Ocorreu um erro durante a migração do banco de dados.");
+        throw;
+    }
+}
 
 // Middleware pipeline
 app.UseXRay("SkillLearning");


### PR DESCRIPTION
Introduces logic to apply pending Entity Framework Core migrations automatically when the application starts. This ensures the database schema is up to date and logs any migration errors.

## ✨ Descrição

Descreva brevemente o que essa PR faz.

## 🧪 O que foi testado?

- [ ] Testes manuais realizados
- [ ] Cobertura de testes automatizados
- [ ] Verificado build e execução

## 🚨 Possui breaking change?

- [ ] Sim
- [ ] Não

## 📋 Checklist

- [ ] PR para `develop`
- [ ] Código limpo e comentado
- [ ] Sem arquivos desnecessários (ex: .vscode, bin/, obj/)
- [ ] Nome da branch segue o padrão `feature/`, `fix/`, `hotfix/`
